### PR TITLE
Update versioning guide to follow semver rules

### DIFF
--- a/_pages/versioning_guidelines.md
+++ b/_pages/versioning_guidelines.md
@@ -8,10 +8,10 @@ permalink: /versioning_guidelines
 
 # Versioning NWB:N Specification Namespaces
 
-* Version: 0.2.0 (DRAFT)
+* Version: 0.3.0 (DRAFT)
 * Authors:
    * Oliver Ruebel
-* Last update: March 29, 2019
+* Last update: April 9, 2020
 
 ## Overview
 
@@ -31,7 +31,7 @@ NWB:N uses semantic versioning for format specifications. Versions are assigned 
 1. MAJOR version is incremented when adding incompatible schema changes,
 2. MINOR version is incremented when functionality is added in a backwards-compatible manner (e.g., addition of new neurodata_types),
 3. PATCH version is incremented when backwards-compatible bug fixes or other changes that do not affect the actual specification (e.g., correction of documentation etc.)
-For public releases NWB:N does not allow custom extensions to the semantic versioning. Custom extensions (e.g., beta, rc) may be used internally on development branches but should be removed for full public release.
+For public releases NWB:N does not allow custom extensions to the semantic versioning. Custom extensions (e.g., "-beta", "-rc") may be used internally on development branches but should be removed for full public release.
 
 ## Versioning rules
 
@@ -49,17 +49,17 @@ For public releases NWB:N does not allow custom extensions to the semantic versi
    2. MINOR version Y (x.Y.z where x > 0) MUST be incremented if new, backwards compatible functionality is introduced to the public specification. It MUST be incremented if any public API functionality is marked as deprecated and if new functionality or improvements are introduced. It MAY include patch level changes. The PATCH version MUST be reset to 0 when MINOR version is incremented. The MINOR version MUST be reset to 0 when the MAJOR version is incremented.
    3. MAJOR version X (X.y.z where  X > 0) MUST be incremented if any backwards incompatible changes are introduced to the public format specification. It MAY include minor and patch level changes. The PATCH and MINOR version MUST be reset to 0 when major version is incremented.
 
-6. Public releases format specification MUST NOT contain custom extensions to the semantic versioning. Custom extensions (e.g., beta, rc) MAY be used internally on development branches but MUST be removed for full public release. For internal releases addition of lowercase alphabetic identifiers (a-z) SHOULD be used. Internal release additions SHOULD be comparable via standard alphabet ordering (e.g,. 1.0.0a < 1.0.0b). Typically, not the full spectrum of available alphabet characters are used for internal pre-releases, e.g., in the case of the following SUGGESTED internal versioning scheme:
+6. Public releases format specification MUST NOT contain custom extensions to the semantic versioning. Custom extensions (e.g., "-beta", "-rc") MAY be used internally on development branches but MUST be removed for full public release. For internal releases, addition of a hyphen followed by lowercase alphabetic identifiers (a-z) SHOULD be used. Internal release additions SHOULD be comparable via standard alphabet ordering (e.g,. 1.0.0a < 1.0.0b). Typically, not the full spectrum of available alphabet characters are used for internal pre-releases, e.g., in the case of the following SUGGESTED internal versioning scheme:
 
-   1. The postfix **a** (e.g., 2.0.1a) may be used to indicate internal alpha releases. Internal alpha releases are considered not stable and under development.
-   2. The postfix **b** (e.g., 2.0.1b) may be used to indicate internal beta releases. Internal beta releases are considered usable but still under development.
-   3. The postfix **rc** (e.g., 2.0.1rc) may be used to indicate internal release candidates. Internal release candidate are considered usable and stable, expecting only minor changes for full public release.
+   1. The postfix **-alpha** (e.g., 2.0.1-alpha) may be used to indicate internal alpha releases. Internal alpha releases are considered not stable and under development.
+   2. The postfix **-beta** (e.g., 2.0.1-beta) may be used to indicate internal beta releases. Internal beta releases are considered usable but still under development.
+   3. The postfix **-rc** (e.g., 2.0.1-rc) may be used to indicate internal release candidates. Internal release candidate are considered usable and stable, expecting only minor changes for full public release.
 
 7. To support versioning of subcomponents of an extension, an extension MAY contain sub-namespaces that are included in the main extension namespace. Sub-namespaces MUST follow the same versioning rules outlined above. In addition the version of the main namespace (and any sub-namespaces that include a corresponding sub-namespace) MUST update their version numbers accordingly when the version of a sub-namespace is incremented.
 
 ## Determining version precedence
 
-Version precedence refers to how versions are compared to each other when ordered. Precedence MUST be calculated by separating the version into MAJOR, MINOR, and PATCH (and for internal pre-release additional alphabetic identifiers) in that order. Precedence is determined by the first difference when comparing each of these identifiers from left to right as follows: MAJOR, MINOR, and PATCH versions are always compared numerically. For example: 1.0.1 < 2.1.0 < 2.2.0 < 2.3.1. Versions with identical MAJOR and MINOR version are considered backward compatible, i.e., a file generated with version 2.0.x MUST be able to be read using all versions 2.0.y (y>=x). Internal pre-release additions to the versioning schema are considered to have lower precedence than regular versions (e.g., 2.0.0a < 2.0.0, i.e., pre-release versions are considered lower than the same regular release version). Precedence for two pre-release versions with the same MAJOR, MINOR, and PATCH version SHOULD be determined by lexical comparison in ASCII sort order (i.e., comparison left-to-right in alphabetic order). E.g.  1.0.0a < 1.0.0b and for internal pre-release additions consisting of multiple letters 1.0.0a < 1.0.0c < 1.0.0ca < 1.0.0cb < 1.0.0d.
+Version precedence refers to how versions are compared to each other when ordered. Precedence MUST be calculated by separating the version into MAJOR, MINOR, and PATCH (and for internal pre-release additional alphabetic identifiers) in that order. Precedence is determined by the first difference when comparing each of these identifiers from left to right as follows: MAJOR, MINOR, and PATCH versions are always compared numerically. For example: 1.0.1 < 2.1.0 < 2.2.0 < 2.3.1. Versions with identical MAJOR and MINOR version are considered backward compatible, i.e., a file generated with version 2.0.x MUST be able to be read using all versions 2.0.y (y>=x). Internal pre-release additions to the versioning schema are considered to have lower precedence than regular versions (e.g., 2.0.0-alpha < 2.0.0, i.e., pre-release versions are considered lower than the same regular release version). Precedence for two pre-release versions with the same MAJOR, MINOR, and PATCH version SHOULD be determined by lexical comparison in ASCII sort order (i.e., comparison left-to-right in alphabetic order). E.g.  1.0.0-a < 1.0.0-b and for internal pre-release additions consisting of multiple letters 1.0.0-a < 1.0.0c < 1.0.0-ca < 1.0.0-cb < 1.0.0-d.
 
 ## References
 


### PR DESCRIPTION
The suggested NWB format for pre-releases / internal releases was x.y.zw where w is comprised of characters [a-z]. 
[Semantic versioning](https://semver.org/spec/v2.0.0.html#spec-item-9) says the format should be x.y.z-w where w is comprised of characters [0-9A-Za-z]. Changing the NWB format to add a hyphen between z and w allows the version to be parsed by semantic versioning checkers.