### PR TITLE
Add link to extensions tutorial

### DIFF
--- a/_pages/home.md
+++ b/_pages/home.md
@@ -10,7 +10,7 @@ permalink: /
 
 The [Neurodata Extensions Catalog (NDX Catalog)](https://github.com/nwb-extensions) is a community-led catalog of extensions to the [Neurodata Without Borders (NWB)](https://neurodatawithoutborders.github.io/) data standard.
 
-To add an extension to this Catalog, please follow the [instructions in the staged-extensions repo](https://github.com/nwb-extensions/staged-extensions).
+To create an NWB extension, please follow [this tutorial](https://nwb-overview.readthedocs.io/en/latest/extensions_tutorial/extensions_tutorial_home.html). To add an extension to this Catalog, follow the [instructions in the staged-extensions repo](https://github.com/nwb-extensions/staged-extensions).
 
 <form action="{{ site.url }}" method="get">
     Filter: <input type="search" name="q" id="search-input" size="70" autofocus>


### PR DESCRIPTION
Fix #9. I think linking to the tutorial is sufficient. The tutorial links to the ndx-template. The template itself does not have much instruction on how to create an extension.