### PR TITLE
Enable scrolling for details preview

### DIFF
--- a/css/main.scss
+++ b/css/main.scss
@@ -211,7 +211,7 @@ table {
 
 .readme-preview {
   height: 300px; /* Adjust this value to your desired height */
-  overflow-y: hidden; /* change to scroll to enable scrolling */
+  overflow-y: scroll; /* change to scroll to enable scrolling */
   position: relative;
   padding-right: 20px;
 }


### PR DESCRIPTION
The expandable "Details" section for each ndx extension currently cuts off longer descriptions, due to the `overflow-y: hidden;` style.

Example: The details of "ndx-events" include a list of Event types, which is cut before the end of the list (there are actually 4 types listed):

<img width="1000" height="461" alt="image" src="https://github.com/user-attachments/assets/9e1688c3-eb96-4588-b4df-02eaed1bbd30" />

With this change, the element becomes scrollable if its contents are too long, enabling users to read the entire description. It's even suggested as a comment in the SCSS. There is no negative impact on the overall layout.